### PR TITLE
this one finally works

### DIFF
--- a/src/main/scala/with_monads/transformers/ReaderT.scala
+++ b/src/main/scala/with_monads/transformers/ReaderT.scala
@@ -1,0 +1,19 @@
+package with_monads
+
+trait ReaderTOps[F[_], A,B] {
+    def runA(a: A): F[B]
+  }
+
+case class ReaderT[F[_]: Monad, A,B](run: A => F[B]) extends ReaderTOps[F,A,B] {
+    def runA(a: A): F[B] = run(a) 
+}
+
+object ReaderT {
+    implicit def monadForStateT[F[_]: Monad, A]: Monad[ReaderT[F, A,*]] = new Monad[ReaderT[F, A,*]] {
+        def flatMap[B, C](fa: ReaderT[F,A,B])(g: B => ReaderT[F,A,C]): ReaderT[F,A,C] = {
+            ReaderT((a) => fa.run(a).flatMap(g(_).run(a)))
+        }
+        def pure[B](b: B): ReaderT[F, A, B] = ReaderT((a) => Monad[F].pure(b))
+    }
+}
+

--- a/src/test/scala/with_monads.scala/ReaderSpec.scala
+++ b/src/test/scala/with_monads.scala/ReaderSpec.scala
@@ -1,0 +1,76 @@
+package with_monads
+
+import org.scalatest._
+import org.scalatest.Matchers._
+import org.scalatest.exceptions.NotAllowedException
+
+class ReaderSpec extends FlatSpec {
+    sealed trait UserAuth
+    final object ReadAccess extends UserAuth
+    final object WriteAccess extends UserAuth
+    final object AdminAccess extends UserAuth
+
+    case class User(username: String, password: String)
+
+    case class Environment(
+    usersByUsername: Map[String, User],
+    userAuthByUser: Map[User, List[UserAuth]]
+    )
+
+    val alex = User("alex.mills", "abc123")
+    val yi = User("yi.fu", "b35t p455w0rd Ev4!")
+    val corey = User("corey.mckenzie", "0m6 s0 57roN6!")
+    val thomas = User("thomas.ibarra", "N3v34 6o1n6 7o 6u3ss 17!")
+
+    val env = new Environment(
+    Map("alex.mills" -> alex,
+        "yi.fu" -> yi,
+        "corey.mckenzie" -> corey,
+        "thomas.ibarra" -> thomas),
+    Map(alex   -> List(ReadAccess),
+        yi     -> List(WriteAccess, ReadAccess),
+        thomas -> List(AdminAccess, WriteAccess, ReadAccess),
+        corey  -> List(AdminAccess, WriteAccess))
+    )
+
+    "Reader" should "Perform Login" in {
+
+        def getUser(username: String): Reader[Environment, Option[User]] = Reader(
+            env => env.usersByUsername.get(username)
+        )
+
+        def getUserPassword(username: String): Reader[Environment, Option[String]] =
+            for {
+                userOpt     <- getUser(username)
+                passwordOpt = userOpt.fold[Option[String]](None)(user => Some(user.password))
+            } yield (passwordOpt)
+
+        def validateUsernameAndPassword(username: String, password: String): Reader[Environment, Boolean] = 
+            for {
+                passwordOpt <- getUserPassword(username)
+            } yield(
+                passwordOpt.fold(false)(correctPass => correctPass.equals(password))
+                )
+
+        def getListUserAuth(user: User): Reader[Environment, Option[List[UserAuth]]] = Reader(
+            env => env.userAuthByUser.get(user)
+        )
+
+        def auth(username: String, password: String): Reader[Environment, Option[List[UserAuth]]] = {
+            // val authorized = for {
+            //     bool <- validateUsernameAndPassword(username, password)
+            // } yield(bool)
+
+            val getOptList = for {
+                    
+                    userOpt     <- getUser(username)
+                    listAuthOpt <- getListUserAuth(userOpt.get)
+                } yield(listAuthOpt)
+            getOptList
+
+        }
+
+    assert(false)        
+
+    }
+}

--- a/src/test/scala/with_monads.scala/ReaderSpec.scala
+++ b/src/test/scala/with_monads.scala/ReaderSpec.scala
@@ -53,7 +53,7 @@ class ReaderSpec extends FlatSpec {
                 )
 
         def getListUserAuth(userOpt: Option[User]): Reader[Environment, Option[List[UserAuth]]] = Reader(
-            env => userOpt.map(user=>env.userAuthByUser.get(user).get)
+            env => userOpt.flatMap(user=>env.userAuthByUser.get(user))
         )
 
         def auth(username: String, password: String): Reader[Environment, Option[List[UserAuth]]] = {

--- a/src/test/scala/with_monads.scala/ReaderTSpec.scala
+++ b/src/test/scala/with_monads.scala/ReaderTSpec.scala
@@ -1,0 +1,69 @@
+package with_monads
+
+import org.scalatest._
+import org.scalatest.Matchers._
+
+class ReaderTSpec extends FlatSpec {
+    sealed trait UserAuth
+    final object ReadAccess extends UserAuth
+    final object WriteAccess extends UserAuth
+    final object AdminAccess extends UserAuth
+
+    case class User(username: String, password: String)
+
+    case class Environment(
+    usersByUsername: Map[String, User],
+    userAuthByUser: Map[User, List[UserAuth]]
+    )
+
+    val alex = User("alex.mills", "abc123")
+    val yi = User("yi.fu", "b35t p455w0rd Ev4!")
+    val corey = User("corey.mckenzie", "0m6 s0 57roN6!")
+    val thomas = User("thomas.ibarra", "N3v34 6o1n6 7o 6u3ss 17!")
+
+    val env = new Environment(
+    Map("alex.mills" -> alex,
+        "yi.fu" -> yi,
+        "corey.mckenzie" -> corey,
+        "thomas.ibarra" -> thomas),
+    Map(alex   -> List(ReadAccess),
+        yi     -> List(WriteAccess, ReadAccess),
+        thomas -> List(AdminAccess, WriteAccess, ReadAccess),
+        corey  -> List(AdminAccess, WriteAccess))
+    )
+
+    "ReaderT" should "be wrapped by Option" in {
+
+        def getUser(username: String): ReaderT[Option, Environment, User] = ReaderT(
+            env => env.usersByUsername.get(username)
+        )
+
+        def getUserPassword(username: String): ReaderT[Option, Environment, String] =
+            for {
+                user <- getUser(username)
+            } yield (user.password)
+
+        def validateUsernameAndPassword(username: String, password: String): ReaderT[Option, Environment, Boolean] = 
+            for {
+                correctPass <- getUserPassword(username)
+            } yield(
+                correctPass == password
+                )
+                
+
+        def getListUserAuth(user: User): ReaderT[Option, Environment, List[UserAuth]] = ReaderT(
+            env => env.userAuthByUser.get(user)
+        )
+
+        def auth(username: String, password: String): ReaderT[Option, Environment, List[UserAuth]] = {
+            for {
+                user              <- getUser(username)
+                isPasswordCorrect <- validateUsernameAndPassword(username, password)
+                listAuthOpt       <- getListUserAuth(user)
+              } yield (if (isPasswordCorrect) listAuthOpt else List.empty)
+        }
+
+    auth("yi.fu", "b35t p455w0rd Ev4!").run(env) should equal(env.userAuthByUser.get(yi))
+
+    }
+}


### PR DESCRIPTION
~~a little flaw in `env => userOpt.map(user=>env.userAuthByUser.get(user).get)`. If a user is in `usersByUsername` map, but not in `userAuthByUser` map, it may throw an exception.~~

change the map to flapMap. It should be good now. 

update: add `ReaderT` and `ReaderTSpec` in this PR. tested and it passed the test. \(^^)/
Although I am really not sure what I was doing.
@kalexmills 